### PR TITLE
Set Plain Text Paste to on by default

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -223,6 +223,8 @@ HTML;
     $init['block_formats'] = "Paragraph=p; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6; Preformatted=pre";
     //make sure kitchen sink is displayed by default
     $init['wordpress_adv_hidden'] = true;
+    //force 'plain text paste' to be on
+    $init['paste_as_text'] = true;
     return $init;
   }
 


### PR DESCRIPTION
Wordpress attempts to clean up and keep any copied nodes from copied text - I would suggest we at least turn plain text paste on by default. 