### PR TITLE
Add a notice to Admin when on local or staging sites

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -31,6 +31,8 @@ class AgreableBase extends TimberSite {
     add_action('login_enqueue_scripts', array($this, 'change_login_logo'));
 
     add_action('admin_menu', array($this, 'wphidenag'));
+    add_action('admin_menu', array($this, 'notify_environment'));
+
 
     add_action('after_setup_theme', array($this, 'remove_post_formats'), 11);
 
@@ -70,6 +72,12 @@ class AgreableBase extends TimberSite {
 
   function wphidenag() {
     remove_action( 'admin_notices', 'update_nag', 3 );
+  }
+
+  function notify_environment() {
+    if (WP_ENV !== 'production') {
+      Jigsaw::show_notice("<b>NOTICE</b>: You are currently on the <b>".strtolower(WP_ENV)."</b> site", 'error');
+    }
   }
 
   /*


### PR DESCRIPTION
@shortlist-digital/owners We've had a few instances where people have erroneously entered data into the staging site post-migration. It's all good when tabbing between multiple projects and environments to get a notice I think? 

Here's how it looks:

<img width="818" alt="screen shot 2015-11-05 at 11 59 56" src="https://cloud.githubusercontent.com/assets/631670/10967768/c3a22640-83b4-11e5-91c2-f838ae9ee982.png">
