### PR TITLE
Remove comment field

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -33,6 +33,7 @@ class AgreableBase extends TimberSite {
     add_action('admin_menu', array($this, 'wphidenag'));
     add_action('admin_menu', array($this, 'notify_environment'));
 
+    add_action('admin_init', array($this, 'edit_post_columns'));
 
     add_action('after_setup_theme', array($this, 'remove_post_formats'), 11);
 
@@ -78,6 +79,13 @@ class AgreableBase extends TimberSite {
     if (WP_ENV !== 'production') {
       Jigsaw::show_notice("<b>NOTICE</b>: You are currently on the <b>".strtolower(WP_ENV)."</b> site", 'error');
     }
+  }
+
+  function edit_post_columns() {
+    add_filter('manage_posts_columns', function() {
+      unset($columns['comments']);
+      return $columns;
+    });
   }
 
   /*

--- a/functions.php
+++ b/functions.php
@@ -82,7 +82,7 @@ class AgreableBase extends TimberSite {
   }
 
   function edit_post_columns() {
-    add_filter('manage_posts_columns', function() {
+    add_filter('manage_posts_columns', function($columns) {
       unset($columns['comments']);
       return $columns;
     });


### PR DESCRIPTION
@shortlist-digital/owners This removes the "comments count" column from the posts list. We don't need them as we don't use WordPress' inbuilt comment functionality.