### PR TITLE
Check if category has widgets. If not populate with latest cat posts

### DIFF
--- a/page.php
+++ b/page.php
@@ -44,6 +44,15 @@ if ($_GET["format"] === 'json') {
   return AgreableApiService::handleRequest("section", $post, $currentPage);
 }
 
+if($post->object_type === 'term'){
+  $has_widgets = count(get_field('rows', 'category_'.$post->ID)) > 0;
+  if(!$has_widgets){
+    $context['manual_posts'] = Timber::get_posts();
+    Timber::render('category-default.twig', $context, false);
+    return;
+  }
+}
+
 if ($_GET['format'] === 'widgets-only') {
   Timber::render('partials/section-widgets.twig', $context, false);
 } else {

--- a/page.php
+++ b/page.php
@@ -44,9 +44,12 @@ if ($_GET["format"] === 'json') {
   return AgreableApiService::handleRequest("section", $post, $currentPage);
 }
 
+// A category archive page with no widgets gets populated
+// with latest posts from this category.
 if($post->object_type === 'term'){
   $has_widgets = count(get_field('rows', 'category_'.$post->ID)) > 0;
   if(!$has_widgets){
+    // 'manual_posts' is the variable being accessed by the Grid widget.
     $context['manual_posts'] = Timber::get_posts();
     Timber::render('category-default.twig', $context, false);
     return;


### PR DESCRIPTION
On category archive page, we check to see if any widgets have been added. If not show some default content. 

@jonsherrard @ecoad I won't self merge this because it affects other live sites.