### PR TITLE
Article layout with no hero. Hero still required because of thumbnail

### DIFF
--- a/custom-fields/article-basic-details.php
+++ b/custom-fields/article-basic-details.php
@@ -176,7 +176,8 @@ register_field_group(array (
       ),
       'choices' => array (
         'article' => 'Standard Article',
-        'gallery' => 'Gallery'
+        'gallery' => 'Gallery',
+        'no-hero' => 'Hero Image Hidden'
       ),
       'default_value' => array (
         'article' => 'article',


### PR DESCRIPTION
A number of requests have been made for hiding the hero image. We still need it to be a required field because it is used as a the thumbnail preview in grids, etc. But can't see the harm in adding an article type and them conditionally hiding it in the app-theme.