### PR TITLE
Removing the override of start and end time

### DIFF
--- a/custom-fields/basic/basic-details.php
+++ b/custom-fields/basic/basic-details.php
@@ -75,24 +75,6 @@ $article_basic_acf = array (
       'required' => 1,
       'preview_size' => 'landscape'
     ),
-    array (
-      'key' => $key . '_override_start_time',
-      'label' => 'Override Start Date & Time',
-      'name' => 'override_start_time',
-      'type' => 'text',
-      'wrapper' => array (
-        'class' => 'acf-hide',
-      ),
-    ),
-    array (
-      'key' => $key . '_override_end_time',
-      'label' => 'Override End Date & Time',
-      'name' => 'override_end_time',
-      'type' => 'text',
-      'wrapper' => array (
-        'class' => 'acf-hide',
-      ),
-    ),
   ),
   'location' => array (
     array (

--- a/libs/services/ListService.php
+++ b/libs/services/ListService.php
@@ -99,60 +99,6 @@ class AgreableListService
         // 'orderby' => 'rand',
         'orderby' => 'date',
         'order' => 'DESC',
-        // Meta query checks for presence of override_end_time &
-        // override_start_time. If they don't exist then we assume
-        // this post doesn't have  any other expiry rules (i.e.
-        // isn't a promo or similar). If it does have both then we
-        // check that time() is within these bounds. Assumes that
-        // meta_value is stored as unix timestamp (seconds).
-        'meta_query'  => array(
-          'relation'    => 'AND',
-          array(
-            'relation'    => 'OR',
-            array(
-              'relation'    => 'AND',
-              array(
-                'key'   => 'override_end_time',
-                'compare' => 'NOT EXISTS',
-                'value'   => '1'
-              ),
-              array(
-                'key'   => 'override_start_time',
-                'compare' => 'NOT EXISTS',
-                'value'   => '1'
-              ),
-            ),
-            array(
-              'relation'    => 'AND',
-              array(
-                'relation'    => 'OR',
-                array(
-                  'key'   => 'override_end_time',
-                  'compare' => '>=',
-                  'value'   => time()
-                ),
-                array(
-                  'key'   => 'override_end_time',
-                  'compare' => '==',
-                  'value'   => '',
-                ),
-              ),
-              array(
-                'relation'    => 'OR',
-                array(
-                  'key'   => 'override_start_time',
-                  'compare' => '<=',
-                  'value'   => time()
-                ),
-                array(
-                  'key'   => 'override_start_time',
-                  'compare' => '==',
-                  'value'   => '',
-                )
-              ),
-            ),
-          ),
-        )
       );
 
             if ($post_type) {


### PR DESCRIPTION
The query that the override of start and end time was incredibly imperformant, especially on large databases, such as Pages Stylist.

Without this functionality editors will now need to schedule posts going live using the standard WP scheduling feature. End times will not be accommodated, so potentially old competitions will surface in Related Posts widget if there isn't much newer content.